### PR TITLE
Make compatible with Slicer-4.11 and small fixes

### DIFF
--- a/BoneThicknessMapping/BoneThicknessMapping.py
+++ b/BoneThicknessMapping/BoneThicknessMapping.py
@@ -737,7 +737,7 @@ class BoneThicknessMappingLogic(ScriptedLoadableModuleLogic):
         castIndex = BoneThicknessMappingLogic.determine_cast_direction_index(ray_direction)
 
         update_status(text="Building intersection object tree...", progress=81)
-        bspTree = vtk.vtkModifiedBSPTree()
+        bspTree = vtk.vtkStaticCellLocator()
         bspTree.SetDataSet(polydata)
         bspTree.BuildLocator()
 
@@ -753,21 +753,37 @@ class BoneThicknessMappingLogic(ScriptedLoadableModuleLogic):
             d = d*gradient_scale_factor
             return d
 
-        def interpret_points(points_of_intersection, mode):
-            if mode is BoneThicknessMappingType.THICKNESS:
-                return calculate_distance(points_of_intersection.GetPoint(0), points_of_intersection.GetPoint(points_of_intersection.GetNumberOfPoints() - 1))
-            elif mode is BoneThicknessMappingType.AIR_CELL:
-                return calculate_distance(points_of_intersection.GetPoint(0), points_of_intersection.GetPoint(1))
+        tol=0.000
+        pc = [0,0,0]
+        subId = vtk.reference(0)
+        cellId = vtk.reference(0) 
+        genCell = vtk.vtkGenericCell()
+        p0 = [0,0,0]
+        p1 = [0,0,0]
+        pLast = [0,0,0]
 
         pointsOfIntersection, cellsOfIntersection = vtk.vtkPoints(), vtk.vtkIdList()
         for i, hitPoint in enumerate(hit_point_list):
             stretchFactor = dimensions[castIndex]
             start = [hitPoint.point[0] + hitPoint.normal[0]*stretchFactor, hitPoint.point[1] + hitPoint.normal[1]*stretchFactor, hitPoint.point[2] + hitPoint.normal[2]*stretchFactor]
             end = [hitPoint.point[0] - hitPoint.normal[0]*stretchFactor, hitPoint.point[1] - hitPoint.normal[1]*stretchFactor, hitPoint.point[2] - hitPoint.normal[2]*stretchFactor]
-            bspTree.IntersectWithLine(start, end, 0, pointsOfIntersection, cellsOfIntersection)
-            if pointsOfIntersection.GetNumberOfPoints() < 2: continue
-            skullThicknessScalarArray.InsertTuple1(hitPoint.pid, interpret_points(pointsOfIntersection, BoneThicknessMappingType.THICKNESS))
-            airCellScalarArray.InsertTuple1(hitPoint.pid, interpret_points(pointsOfIntersection, BoneThicknessMappingType.AIR_CELL))
+            bspTree.FindCellsAlongLine(start, end, tol, cellsOfIntersection)
+            distances = []
+            for cellIndex in range(cellsOfIntersection.GetNumberOfIds()):
+                t = vtk.reference(0.0)
+                p=[0.0, 0.0, 0.0]
+                if polydata.GetCell(cellsOfIntersection.GetId(cellIndex)).IntersectWithLine(start, end, tol, t, p, pc, subId) and 0.0 <= t and t <= 1.0:
+                    distances.append([t,p])
+            if len(distances) >= 2:
+                distances = sorted(distances, key=lambda kv: kv[0])
+                p0=distances[0][1]
+                p1=distances[1][1]
+                pLast=distances[-1][1]
+                skullThicknessScalarArray.InsertTuple1(hitPoint.pid, calculate_distance(p0, pLast))
+                airCellScalarArray.InsertTuple1(hitPoint.pid, calculate_distance(p0, p1))
+            else:
+                skullThicknessScalarArray.InsertTuple1(hitPoint.pid, 0)
+                airCellScalarArray.InsertTuple1(hitPoint.pid, 0)
             # update rays casted status
             if i%200 == 0: update_status(text="Calculating thickness (~{0} of {1} rays)".format(i,total), progress=82 + int(round((i*1.0/total*1.0)*18.0)))
         update_status(text="Finished thickness calculation in " + str("%.1f" % (time.time() - startTime)) + "s...", progress=100)


### PR DESCRIPTION
- xrange is not available in Python3
- segmentation GetClosedSurfaceRepresentation API changed
- reset_view method used hardcoded (and incorrect) constant values
- give more fine-grained feedback during thickness computation