### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/BoneThicknessMapping/BoneThicknessMapping.py
+++ b/BoneThicknessMapping/BoneThicknessMapping.py
@@ -584,8 +584,8 @@ class BoneThicknessMappingWidget(ScriptedLoadableModuleWidget):
         # BoneThicknessMappingLogic.reset_view(self.CONFIG_rayCastAxis)
 
     def click_toggle_scalar_bar(self, state):
-        if state is 0: BoneThicknessMappingLogic.set_scalar_colour_bar_state(0)
-        elif state is 2:
+        if state == 0: BoneThicknessMappingLogic.set_scalar_colour_bar_state(0)
+        elif state == 2:
             if self.displayThicknessSelector.isChecked(): BoneThicknessMappingLogic.set_scalar_colour_bar_state(1, self.thicknessColourNode)
             elif self.displayFirstAirCellSelector.isChecked(): BoneThicknessMappingLogic.set_scalar_colour_bar_state(1, self.airCellColourNode)
 
@@ -890,7 +890,7 @@ class BoneThicknessMappingLogic(ScriptedLoadableModuleLogic):
                 skullThicknessArray.InsertTuple1(hitPoint.pid, 0)
                 airCellDistanceArray.InsertTuple1(hitPoint.pid, 0)
             # update rays casted status
-            if i % 200 == 0: update_status(text="Calculating thickness (~{0} of {1} rays)".format(i, total), progress=82 + int(round((i*1.0/total*1.0)*18.0)))
+            if i % 200 == 0: update_status(text=f"Calculating thickness (~{i} of {total} rays)", progress=82 + int(round((i*1.0/total*1.0)*18.0)))
         update_status(text="Finished thickness calculation in " + str("%.1f" % (time.time() - startTime)) + "s...", progress=100)
         return skullThicknessArray, airCellDistanceArray
 
@@ -935,6 +935,6 @@ class BoneThicknessMappingLogic(ScriptedLoadableModuleLogic):
         colorWidget = slicer.modules.colors.widgetRepresentation()
         ctkBar = slicer.util.findChildren(colorWidget, name='VTKScalarBar')[0]
         ctkBar.setDisplay(state)
-        if state is 0 or color_node_id is None: return
+        if state == 0 or color_node_id is None: return
         slicer.util.findChildren(colorWidget, 'ColorTableComboBox')[0].setCurrentNodeID(color_node_id)
         slicer.util.findChildren(colorWidget, 'UseColorNameAsLabelCheckBox')[0].setChecked(True)


### PR DESCRIPTION
Some syntax upgrading is necessary for Slicer-BoneThicknessMapping as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2625773 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+, 3.8+ or 3.9+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/Slicer-BoneThicknessMapping"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```